### PR TITLE
Fix 'false' values handling for options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,15 +31,15 @@ const markdownIntoHtml = async ({ path, url, options }) => {
 
     // markdown-it options
     const md_options = {
-        html: (options && options.html) || true,
-        xhtmlOut: (options && options.xhtmlOut) || true,
-        breaks: (options && options.breaks) || true,
-        linkify: (options && options.linkify) || true,
-        typographer: (options && options.typographer) || true,
+        html: (options && options.html !== undefined) ? options.html : true,
+        xhtmlOut: (options && options.xhtmlOut !== undefined) ? options.xhtmlOut : true,
+        breaks: (options && options.breaks !== undefined) ? options.breaks : true,
+        linkify: (options && options.linkify !== undefined) ? options.linkify : true,
+        typographer: (options && options.typographer !== undefined) ? options.typographer : true,
         langPrefix: (options && options.langPrefix) || 'language-',
         quotes: (options && options.quotes) || '“”‘’',
-        emoji: (options && options.emoji) || true,
-        taskLists: (options && options.taskLists) || true,
+        emoji: (options && options.emoji !== undefined) ? options.emoji : true,
+        taskLists: (options && options.taskLists !== undefined) ? options.taskLists : true,
     }
 
     const md = new markdownIt()


### PR DESCRIPTION
Fixes #1 

Devs weren't able to pass 'false' values for options
because default 'true' values were used in all the cases when
option value is falsy (undefined, false etc.)

This change explicitly checks not-passed options with
strict equality check to undefined.